### PR TITLE
fix: do not download covers when URL is an empty string

### DIFF
--- a/ymd/ym_api/models.py
+++ b/ymd/ym_api/models.py
@@ -19,7 +19,9 @@ class CoverInfo:
     @classmethod
     def from_json(cls, data: dict) -> 'CoverInfo':
         og_image = data.get("ogImage")
-        return cls(f'https://{og_image}' if og_image is not None else None)
+        if og_image is None or og_image == "":
+            return cls(None)
+        return cls(f'https://{og_image}')
 
 
 @dataclass


### PR DESCRIPTION
Hi!
It appears that cover URL could also be an empty string, not just `None`. This PR fixes the bug when downloader crashes on an attempt to download such cover.

PS: sorry for the duplicate PRs, I've closed all irrelevant ones. 