### PR TITLE
Added support for 'track-number' placeholder

### DIFF
--- a/ymd/cli.py
+++ b/ymd/cli.py
@@ -131,7 +131,7 @@ def main():
         help=show_default(
             "Поддерживает следующие заполнители:"
             " #number, #artist, #album-artist, #title,"
-            " #album, #year, #artist-id, #album-id, #track-id"
+            " #album, #year, #artist-id, #album-id, #track-id, #track-number"
         ),
     )
 
@@ -237,9 +237,14 @@ def main():
     print(f"Треков: {len(result_tracks)}")
 
     covers_cache: dict[str, bytes] = {}
+    track_number = 0
+    # track number should be padded to an appropriate string width with zeroes, e.g:
+    # up to 99 tracks in total - 01, 02, ...; up to 999 tracks - 001, 002, ...; etc.
+    track_number_pad = len(str(len(result_tracks))) # get max track number width
     for track in result_tracks:
+        track_number += 1
         save_path = args.dir / core.prepare_track_path(
-            args.path_pattern, track, args.unsafe_path
+            args.path_pattern, track, args.unsafe_path, str(track_number).zfill(track_number_pad)
         )
         if args.skip_existing and save_path.is_file():
             continue

--- a/ymd/cli.py
+++ b/ymd/cli.py
@@ -238,13 +238,14 @@ def main():
 
     covers_cache: dict[str, bytes] = {}
     track_number = 0
-    # track number should be padded to an appropriate string width with zeroes, e.g:
-    # up to 99 tracks in total - 01, 02, ...; up to 999 tracks - 001, 002, ...; etc.
-    track_number_pad = len(str(len(result_tracks))) # get max track number width
+    track_number_pad = len(str(len(result_tracks)))
     for track in result_tracks:
         track_number += 1
         save_path = args.dir / core.prepare_track_path(
-            args.path_pattern, track, args.unsafe_path, str(track_number).zfill(track_number_pad)
+            args.path_pattern,
+            track,
+            args.unsafe_path,
+            str(track_number).zfill(track_number_pad),
         )
         if args.skip_existing and save_path.is_file():
             continue

--- a/ymd/core.py
+++ b/ymd/core.py
@@ -19,7 +19,10 @@ DEFAULT_COVER_RESOLUTION = 400
 
 
 def prepare_track_path(
-    path_pattern: Path, track: BasicTrackInfo, unsafe_path: bool = False, track_number_str: str = ""
+    path_pattern: Path,
+    track: BasicTrackInfo,
+    unsafe_path: bool = False,
+    track_number_str: str = "",
 ) -> Path:
     path_str = str(path_pattern)
     album = track.album
@@ -29,7 +32,7 @@ def prepare_track_path(
         "#artist-id": artist.name,
         "#album-id": album.id,
         "#track-id": track.id,
-        "#track-number": track_number_str,
+        "#number-padded": track_number_str,
         "#number": track.number,
         "#artist": artist.name,
         "#title": track.title,

--- a/ymd/core.py
+++ b/ymd/core.py
@@ -19,7 +19,7 @@ DEFAULT_COVER_RESOLUTION = 400
 
 
 def prepare_track_path(
-    path_pattern: Path, track: BasicTrackInfo, unsafe_path: bool = False
+    path_pattern: Path, track: BasicTrackInfo, unsafe_path: bool = False, track_number_str: str = ""
 ) -> Path:
     path_str = str(path_pattern)
     album = track.album
@@ -29,6 +29,7 @@ def prepare_track_path(
         "#artist-id": artist.name,
         "#album-id": album.id,
         "#track-id": track.id,
+        "#track-number": track_number_str,
         "#number": track.number,
         "#artist": artist.name,
         "#title": track.title,


### PR DESCRIPTION
Added support for 'track-number' placeholder for `--path-pattern` argument like this:
```
--path-pattern "#track-number - #title"
```

so track filenames in a given album could keep their original ordering:
```
01 - The Show Must Go On.mp3
02 - Stayin' Alive.mp3
...
99 - Hotel California.mp3
```

padding with appropriate number of zeroes is supported to make alphabetical sorting work properly.