### PR TITLE
Добавить флаг --skip-broken для пропуска недоступных частей или частей с ошибками.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ python3 main.py --browser "<браузер>" --url "https://music.yandex.ru/albu
 ## Использование
 
 ```
-usage: __main__.py [-h] [--hq] [--skip-existing] [--skip-broken]
-                   [--add-lyrics] [--embed-cover] [--cover-resolution <Разрешение обложки>]
+usage: __main__.py [-h] [--hq] [--skip-existing] [--add-lyrics]
+                   [--embed-cover] [--cover-resolution <Разрешение обложки>]
                    [--delay <Задержка>] [--stick-to-artist] [--only-music]
                    (--artist-id <ID исполнителя> | --album-id <ID альбома> | --track-id <ID трека> | --playlist-id <владелец плейлиста>/<тип плейлиста> | -u URL)
                    [--unsafe-path] [--dir <Папка>] [--path-pattern <Паттерн>]
@@ -86,7 +86,6 @@ options:
 Общие параметры:
   --hq                  Загружать треки в высоком качестве
   --skip-existing       Пропускать уже загруженные треки
-  --skip-broken         Пропускать треки с ошибками вместо остановки всего процесса
   --add-lyrics          Загружать тексты песен
   --embed-cover         Встраивать обложку в .mp3 файл
   --cover-resolution <Разрешение обложки>
@@ -110,8 +109,8 @@ ID:
   --path-pattern <Паттерн>
                         Поддерживает следующие заполнители: #number, #artist,
                         #album-artist, #title, #album, #year, #artist-id,
-                        #album-id, #track-id (по умолчанию: #album-
-                        artist/#album/#number - #title)
+                        #album-id, #track-id, #track-number (по умолчанию:
+                        #album-artist/#album/#number - #title)
 
 Авторизация:
   --browser BROWSER     Браузер из которого будут извлечены данные для

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ python3 main.py --browser "<браузер>" --url "https://music.yandex.ru/albu
 ## Использование
 
 ```
-usage: __main__.py [-h] [--hq] [--skip-existing] [--add-lyrics]
-                   [--embed-cover] [--cover-resolution <Разрешение обложки>]
+usage: __main__.py [-h] [--hq] [--skip-existing] [--skip-broken]
+                   [--add-lyrics] [--embed-cover] [--cover-resolution <Разрешение обложки>]
                    [--delay <Задержка>] [--stick-to-artist] [--only-music]
                    (--artist-id <ID исполнителя> | --album-id <ID альбома> | --track-id <ID трека> | --playlist-id <владелец плейлиста>/<тип плейлиста> | -u URL)
                    [--unsafe-path] [--dir <Папка>] [--path-pattern <Паттерн>]
@@ -86,6 +86,7 @@ options:
 Общие параметры:
   --hq                  Загружать треки в высоком качестве
   --skip-existing       Пропускать уже загруженные треки
+  --skip-broken         Пропускать треки с ошибками вместо остановки всего процесса
   --add-lyrics          Загружать тексты песен
   --embed-cover         Встраивать обложку в .mp3 файл
   --cover-resolution <Разрешение обложки>

--- a/ymd/cli.py
+++ b/ymd/cli.py
@@ -272,7 +272,7 @@ def main():
                 skip_broken=args.skip_broken,
             )
         except Exception as e:
-            if skip_broken:
-                logger.error(f"Не удалось загрузить {save_path}: {traceback.format_exc()}")
+            if args.skip_broken:
+                logger.error(f"Не удалось загрузить {save_path}: {track.items()}. {traceback.format_exc()}")
             else:
                 raise e

--- a/ymd/cli.py
+++ b/ymd/cli.py
@@ -6,6 +6,7 @@ import re
 import sys
 import tempfile
 import time
+import traceback
 from pathlib import Path
 from typing import Optional
 
@@ -64,6 +65,9 @@ def main():
     )
     common_group.add_argument(
         "--skip-existing", action="store_true", help="Пропускать уже загруженные треки"
+    )
+    common_group.add_argument(
+        "--skip-broken", action="store_true", help="Пропускать треки с ошибками вместо остановки всего процесса"
     )
     common_group.add_argument(
         "--add-lyrics", action="store_true", help="Загружать тексты песен"
@@ -255,13 +259,20 @@ def main():
             save_dir.mkdir(parents=True)
 
         print(f"Загружается {save_path}")
-        core.download_track(
-            session=session,
-            track=track,
-            target_path=save_path,
-            hq=args.hq,
-            add_lyrics=args.add_lyrics,
-            embed_cover=args.embed_cover,
-            cover_resolution=args.cover_resolution,
-            covers_cache=covers_cache,
-        )
+        try:
+            core.download_track(
+                session=session,
+                track=track,
+                target_path=save_path,
+                hq=args.hq,
+                add_lyrics=args.add_lyrics,
+                embed_cover=args.embed_cover,
+                cover_resolution=args.cover_resolution,
+                covers_cache=covers_cache,
+                skip_broken=args.skip_broken,
+            )
+        except Exception as e:
+            if skip_broken:
+                logger.error(f"Не удалось загрузить {save_path}: {traceback.format_exc()}")
+            else:
+                raise e

--- a/ymd/core.py
+++ b/ymd/core.py
@@ -118,7 +118,7 @@ def download_track(
                 lyrics = full_track.lyrics
     except Exception as e:
         if skip_broken:
-            logger.error(f"Не удалось загрузить текст песни: {traceback.format_exc()}")
+            logger.error(f"Не удалось загрузить текст песни: {track.full_info.items()}. {traceback.format_exc()}")
         else:
             raise e
 
@@ -139,7 +139,7 @@ def download_track(
                     http_utils.download_file(session, cover_url, cover_path)
     except Exception as e:
         if skip_broken:
-            logger.error(f"Не удалось загрузить обложку: {traceback.format_exc()}")
+            logger.error(f"Не удалось загрузить обложку: {track.full_info.items()}. {traceback.format_exc()}")
         else:
             raise e
 

--- a/ymd/ym_api/api.py
+++ b/ymd/ym_api/api.py
@@ -27,7 +27,7 @@ def get_track_download_url(session: Session, track: BasicTrackInfo, hq: bool) ->
     return f"https://{host}/get-mp3/{path_hash}/{ts}/{path}?track-id={track.id}"
 
 
-def get_full_track_info(session: Session, track_id: str) -> FullTrackInfo:
+def get_full_track_info(session: Session, track_id: str) -> Optional[FullTrackInfo]:
     params = {"track": track_id, "lang": "ru"}
     resp = session.get("https://music.yandex.ru/handlers/track.jsx", params=params)
     return FullTrackInfo.from_json(resp.json())

--- a/ymd/ym_api/models.py
+++ b/ymd/ym_api/models.py
@@ -92,6 +92,7 @@ class BasicTrackInfo:
     artists: list[BasicArtistInfo]
     has_lyrics: bool
     cover_info: CoverInfo
+    full_info: dict
 
     @classmethod
     def from_json(cls, data: dict) -> Optional["BasicTrackInfo"]:
@@ -130,9 +131,10 @@ class BasicTrackInfo:
                 album=album,
                 has_lyrics=has_lyrics,
                 cover_info=cover_info,
+                full_info=data
             )
         except Exception:
-            logger.error(traceback.format_exc())
+            logger.error(f"Ошибка парсинга BasicTrackInfo: {data.items()}. {traceback.format_exc()}")
             return None
 
     @property
@@ -151,7 +153,7 @@ class FullTrackInfo(BasicTrackInfo):
             lyrics = data["lyric"][0]["fullLyrics"]
             return cls(**base.__dict__, lyrics=lyrics)
         except Exception:
-            logger.error(traceback.format_exc())
+            logger.error(f"Ошибка парсинга FullTrackInfo: {data.items()}. {traceback.format_exc()}")
             return None
 
 


### PR DESCRIPTION
Добавляет флаг --skip-broken, который игнорирует либо часть (текст или обложка) или песню в альбоме/плейлисте целиком. При этом ошибка выводится пользователю.

Протестировал на своём плейлисте с 3к песен, где было несколько "сломанных" песен. Сломанная - с ошибками Json на бекенде.