### PR TITLE
Pin `yandex-music` dep at a newest version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-yandex-music
+yandex-music @ git+https://github.com/MarshalX/yandex-music-api.git
 mutagen
 StrEnum


### PR DESCRIPTION
Running the downloader with default dependencies  fails with
```
Traceback (most recent call last):
  File "/usr/local/bin/yandex-music-downloader", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/ymd/cli.py", line 270, in main
    playlist = typing.cast(Playlist, client.users_playlists(kind, user))
  File "/usr/local/lib/python3.9/site-packages/yandex_music/client.py", line 70, in wrapper
    result = method(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/yandex_music/client.py", line 874, in users_playlists
    return Playlist.de_json(result, self)
  File "/usr/local/lib/python3.9/site-packages/yandex_music/playlist/playlist.py", line 453, in de_json
    data['tracks'] = TrackShort.de_list(data.get('tracks'), client)
  File "/usr/local/lib/python3.9/site-packages/yandex_music/track_short.py", line 102, in de_list
    return [cls.de_json(track, client) for track in data]
  File "/usr/local/lib/python3.9/site-packages/yandex_music/track_short.py", line 102, in <listcomp>
    return [cls.de_json(track, client) for track in data]
  File "/usr/local/lib/python3.9/site-packages/yandex_music/track_short.py", line 83, in de_json
    data['track'] = Track.de_json(data.get('track'), client)
  File "/usr/local/lib/python3.9/site-packages/yandex_music/track/track.py", line 490, in de_json
    data['artists'] = Artist.de_list(data.get('artists'), client)
  File "/usr/local/lib/python3.9/site-packages/yandex_music/artist/artist.py", line 306, in de_list
    artists.append(cls.de_json(artist, client))
  File "/usr/local/lib/python3.9/site-packages/yandex_music/artist/artist.py", line 288, in de_json
    return cls(client=client, **data)
TypeError: __init__() missing 1 required positional argument: 'id'
```

Apparently, Ya.API has been changed and the problem was addressed in https://github.com/MarshalX/yandex-music-api/pull/663. However, `yandex-music-api` does not release new versions on PiP (the last version 2.2.0 was uploaded on Dec, 2023). Let's pin the dep at the repo HEAD. We can remove the pin once  `yandex-music-api` resumes releases.